### PR TITLE
add linkage func and prop for bs-multi-select

### DIFF
--- a/uliweb_ui/src/tags/query_condition.tag
+++ b/uliweb_ui/src/tags/query_condition.tag
@@ -219,6 +219,75 @@
             nonSelectedText: opts.field.placeholder || '请选择',
             maxHeight: 200
             }, opts.field.opts || {})
+
+        if (opts.field.relate_from) {
+          if (!opts.field.choices_url) {
+            // 静态
+            var trigger_name = opts.field.relate_from;
+            var trigger = $($('[name="' + trigger_name + '"]')[0]);
+            var actor = $($('[name="' + opts.field.name + '"]')[0]);
+            var relation_kv = opts.field.relationship;
+            var actor_full_choices = opts.field.choices;
+
+            $('body').on('change', '[name="' + trigger_name + '"]', function(){
+              var trigger_selected = trigger.val();
+              var allow_options = [];
+              $.each(trigger_selected || [], function(){
+                if (isNaN(parseInt(this))) {
+                  Array.prototype.push.apply(allow_options, relation_kv[this]);
+                } else {
+                  Array.prototype.push.apply(allow_options, relation_kv[parseInt(this)]);
+                }
+              });
+
+              opts.field.choices = [];
+              $.each(actor_full_choices, function() {
+                if (allow_options.indexOf(""+this[0]) > -1) {
+                  opts.field.choices.push(this);
+                }
+              });
+
+              self.update();
+              if ($.fn.multiselect) {
+                actor.multiselect('rebuild');
+              }
+            });
+          } else {
+            // 动态
+            var trigger_name = opts.field.relate_from;
+            var trigger = $($('[name="' + trigger_name + '"]')[0]);
+            var actor = $($('[name="' + opts.field.name + '"]')[0]);
+
+            $('body').on('change', '[name="' + trigger_name + '"]', function(){
+              var trigger_selected = trigger.val();
+              if (!!trigger_selected && typeof(trigger_selected) == 'object') {
+                if (trigger_selected.length >= 2) {
+                  trigger_selected = trigger_selected.join(',');
+                } else if (trigger_selected.length == 1) {
+                  trigger_selected = trigger_selected[0];
+                } else {
+                  trigger_selected = "-1";
+                }
+              } else {
+                trigger_selected = "-1";
+              }
+              $.ajax({
+                method: "post",
+                url: opts.field.choices_url + '/' + trigger_selected,
+                success: function(result) {
+                  opts.field.choices = result;
+
+                  self.update();
+                  if ($.fn.multiselect) {
+                    actor.multiselect('rebuild');
+                  }
+                }
+              }); // END OF AJAX
+            });
+          } // END OF ELSE
+          trigger.trigger("change");
+        }
+
         load('ui.bootstrap.multiselect', function(){
           var el = $('[name='+opts.field.name+']', self.root).multiselect(_opts);
           if (opts.data[opts.field.name])
@@ -237,7 +306,7 @@
       } else {
       }
       if (opts.data[opts.field.name])
-        if (typeof(opts.data[opts.field.name]) == "string") {
+        if (opts.type == "select" || typeof(opts.data[opts.field.name]) == "string") {
           $('[name='+opts.field.name+']').val(opts.data[opts.field.name])
         } else {
           $($('[name='+opts.field.name+']')[0]).val(opts.data[opts.field.name][0]);


### PR DESCRIPTION
如需使用uliweb.form.SelectField，需要在**init**()和to_json()中添加relate_from,relationship,和choices_url参数。
在前端传给query_condition的配置的fields中添加如下代码测试：
          {name:'ms-trigger', type:'select', label:'联动多选-触发',
              choices:[['1', '选择一'], ['2', '选择二'], ['3', '选择三']],
              placeholder:'请选择', multiple:true, opts:{allSelectedText:'所有选项已经选中'}
          },
          {name:'ms-actor', type:'select', label:'联动多选-响应',
              placeholder:'请选择', multiple:true, opts:{allSelectedText:'所有选项已经选中'},
              // link action common
              relate_from: 'ms-trigger',
              // load choices statically
              choices:[['1', '1-选择一'], ['2', '1-选择二'], ['3', '2-选择三'], ['4', '3-选择四']],
              relationship: {
                '1': ['1', '2'],
                '2': ['3'],
                '3': ['4']
              },
              // load choices dynamically
              //choices_url: '/get/choices/by/ms-trigger' // 需要后台方法支持
          },
