### PR TITLE
rgrid add cols-combine basic function

### DIFF
--- a/uliweb_ui/src/tags/rgrid.tag
+++ b/uliweb_ui/src/tags/rgrid.tag
@@ -91,7 +91,8 @@
     onSelected: opts.onSelected,
     onDeselected: opts.onDeselected,
     draggable: opts.draggable,
-    editable: opts.editable
+    editable: opts.editable,
+    combine_cols: opts.combine_cols || []
 
   }
 


### PR DESCRIPTION
增加合并单元格方法。
使用时在传入rgrid的参数中增加theme: 'simple', combine_cols:[COL_NAME1, COL_NAME2]

注意：
    合并的单元格在cols的设置中frozen属性必须为True，也就是说目前只支持冻结列的合并。且combine_cols的顺序等于合并单元格的分组优先级。
