### PR TITLE
Add gulp and uliweb command to concat plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ you_want_name = [ "plugin name", ... ]
 
 Step.2 Enter a command in CLI of your uliweb project
 
-'''
+```
 uliweb gulpplugins -d app_name
-'''
+```
 
 Then you will find some files in the folder(you_want_name.js && you_want_name.css)
 
-'''
+```
 .../your_project/apps/app_name/static/
-'''
+```
 
 Step.3 In the template file, use plugin with command "{{use 'plugin name'}}" , you_want_name.js and you_want_name.css will loaded
        

--- a/README.md
+++ b/README.md
@@ -34,3 +34,26 @@ project, and just add `uliweb_ui` to `INSTALLED_APPS`, and run the command.
 Uliweb_ui is already create `jsmodule.js` for you. But if you want to add more ui components
 to settings.ini, and also want to use `load` to process them, you should recreate `jsmodules.js`
 yourself.
+
+## Concat plugins
+Step.1 Write some configuration in 'settings.ini' of your uliweb project. like that:
+
+'''
+[TEMPLATE_GULP]
+you_want_name = [ "plugin name", ... ]
+'''
+
+Step.2 Enter a command in CLI of your uliweb project
+
+'''
+uliweb gulpplugins -d app_name
+'''
+
+Then you will find some files in the folder(you_want_name.js && you_want_name.css)
+
+'''
+.../your_project/apps/app_name/static/
+'''
+
+Step.3 In the template file, use plugin with command "{{use 'plugin name'}}" , you_want_name.js and you_want_name.css will loaded
+       

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ yourself.
 ## Concat plugins
 Step.1 Write some configuration in 'settings.ini' of your uliweb project. like that:
 
-'''
+```
 [TEMPLATE_GULP]
 you_want_name = [ "plugin name", ... ]
-'''
+```
 
 Step.2 Enter a command in CLI of your uliweb project
 

--- a/uliweb_ui/__init__.py
+++ b/uliweb_ui/__init__.py
@@ -12,3 +12,38 @@ def load_jquery(**kwargs):
         a.append('modules/jquery/jquery-migrate-1.2.1.min.js')
 
     return a
+
+def init_static_combine():
+
+    from uliweb import settings
+    from hashlib import md5
+    import os
+
+    PLUGINS = settings.get_var("TEMPLATE_GULP")
+
+    d = {}
+
+
+    if settings.get_var('STATIC_COMBINE_CONFIG/enable', False):
+        # for k, v in settings.get('STATIC_COMBINE', {}).items():
+        #     key = '_cmb_' + md5(''.join(v)).hexdigest() + os.path.splitext(v[0])[1]
+        #     d[key] = v
+        from uliweb.contrib.template.tags import find
+        for k, v in PLUGINS.items():
+            js_list = []
+            css_list = []
+            for x in v:
+                s = find(x)
+                m = s[0] + s[1]
+                for i in m:
+                    if not i.startswith('<!--'):
+                        e = os.path.splitext(i)[1]
+                        if e == ".css":
+                            css_list.append(i)
+                        elif e == ".js":
+                            js_list.append(i)
+            if js_list:
+                d[k+".js"] = js_list
+            if css_list:
+                d[k + ".css"] = css_list
+    return d

--- a/uliweb_ui/commands.py
+++ b/uliweb_ui/commands.py
@@ -1,3 +1,4 @@
+# coding:utf-8
 import sys
 from uliweb.core.commands import Command, CommandManager, get_commands
 from optparse import make_option
@@ -63,5 +64,77 @@ class JsmoduleCommand(Command):
         with open(filename, 'wb') as f:
             f.write('var jsmodules = ')
             f.write(json_dumps(d))
+
+
+# Generate a setting file which type is ini for gulp then call gulp cli to concat plugin file
+# by Lihouxuan
+class GulpPlugins(Command):
+
+    name = 'gulpplugins'
+
+    option_list = (
+        make_option('-a', '--app', dest='app', help='App name which settings.ini will be parsed.'),
+        make_option('-d', '--dest', help='Output file will be saved in this app/static directory'),
+    )
+
+    help = 'Convert TEMPLATE_USE config to gulp_settings.ini, ' \
+           'so that gulp can easily use to generate file of common which is concated'
+
+    args = ''
+
+    check_apps_dirs = True
+
+    check_apps = True
+
+    skip_options = False
+
+    options_inherit = True
+
+    def handle(self, options, global_options, *args):
+        from uliweb.utils.pyini import Ini
+        from uliweb.utils.common import pkg
+        from uliweb.contrib.template.tags import find
+        from uliweb.contrib.staticfiles import url_for_static
+        from uliweb import json_dumps
+        import ConfigParser
+
+        if not options.dest and not options.app:
+            print "Error: Please use -d to specify output app"
+            sys.exit(1)
+
+        app = self.get_application(global_options)
+
+        from uliweb import settings
+
+        if options.dest:
+            filename = pkg.resource_filename(options.dest, 'gulp_settings.ini')
+        else:
+            filename = pkg.resource_filename(options.app, 'gulp_settings.ini')
+
+        with open(filename, 'wb') as f:
+            template_gulp = settings.get("TEMPLATE_GULP", {}) # 导出settings中的gulp配置
+            template_use_keys = settings.get("TEMPLATE_USE", {}).keys() # 导出settings中的plugins的名字
+            for dist,items in template_gulp.items():
+                # 有序遍历gulp的concat配置
+                item_dist = dist
+                for name in items:
+                    if name in template_use_keys:
+                        # 如果plugins中有该插件则在ini中写入该配置
+                        s = find(name)
+                        m = s[0] + s[1]
+                        f.write("[template_use." + name + "]\r\n")
+                        for i in m:
+                            if not i.startswith('<!--'):
+                                f.write("toplinks[] = " + app.get_file(i, 'static') + "\r\n")
+                        f.write("dist = " + item_dist + "\r\n")
+                    f.write("\r\n")
+
+        gulp_dist = pkg.resource_filename(options.dest, '/static');
+        gulp_settings = filename
+        gulp_path = pkg.resource_filename("uliweb_ui","")
+        import os
+        terminal_command = "cd "+gulp_path+ " && gulp  --dist " + gulp_dist + " --settings " + gulp_settings
+        os.system(terminal_command)
+
 
 

--- a/uliweb_ui/gulpfile.js
+++ b/uliweb_ui/gulpfile.js
@@ -1,0 +1,147 @@
+/**
+ * Created by HoseaLee on 16/11/25.
+ */
+
+var gulp = require("gulp"),
+    concat = require("gulp-concat"), //文件合并
+    minifycss = require("gulp-minify-css"), //css压缩
+    uglify = require("gulp-uglify"), //js压缩
+    //jshint = require("gulp-jshint"), //js检测
+    htmlmin = require("gulp-htmlmin"), //html压缩
+    imagemin = require("gulp-imagemin"), //图片压缩
+    pngcrush = require("imagemin-pngcrush"),
+    rename = require("gulp-rename"),    //文件更名
+    notify = require("gulp-notify");    //提示信息
+
+var node_ini = require("node-ini"); //node读写ini文件组件
+var minimist = require("minimist"); //命令行
+
+var knownOptions = {
+    string: 'dist',
+    string: 'settings',
+};
+
+var options = minimist(process.argv.slice(2), knownOptions);
+
+if((!options.dist) || (!options.settings)){
+    console.log("Please give two arguments(--dist, --settings)");
+    return false;
+}
+
+//ui和layout
+var path = {
+    uliweb_ui: '/Users/HoseaLee/Workspace/Uliwebext/uliweb-ui/uliweb_ui',
+    uliweb_layout: '/Users/HoseaLee/Workspace/Uliwebext/uliweb-layout/uliweb_layout/'
+};
+
+//插件版本信息,需要时从该对象中取
+var ui_versions = {
+    'ui.bootstrap3': '3.3.6',
+    'ui.fontawesome': '4.6.3',
+    'ui.ionicons': '2.0.1',
+    'ui.jquery': '1.12.4',
+    'ui.jqueryui': '1.11.4',
+    'ui.lodash': '3.10.1',
+    'ui.riot': '2.6.2',
+    'ui.ag-grid': '4.2.5',
+    'ui.ueditor': '1.4.3.3',
+    'ui.echarts': '3.2.3',
+    'ui.ztree': '3.5.24'
+};
+
+var common_css_list = [
+    {
+        project: "ui",
+        path: path['uliweb_ui'] + '/static/modules/jquery-ui/' + ui_versions['ui.jqueryui'] + '/jquery-ui.min.css'
+    },
+    {
+        project: "ui",
+        path: path['uliweb_ui'] + '/static/modules/bootstrap/' + ui_versions['ui.bootstrap3'] + '/css/bootstrap.min.css'
+    },
+    {
+        project: "ui",
+        path: path['uliweb_ui'] + '/static/modules/font-awesome/' + ui_versions['ui.fontawesome'] + '/css/font-awesome.min.css'
+    },
+    {
+        project: "ui",
+        path: path['uliweb_ui'] + '/static/modules/ionicons/' + ui_versions['ui.ionicons'] + '/css/ionicons.min.css'
+    },
+    {project: "layout", path: path['uliweb_layout'] + '/layout/static/adminlte/2.3.2/css/AdminLTE.min.css'},
+    {project: "layout", path: path['uliweb_layout'] + '/layout/static/adminlte/2.3.2/css/skins/_all-skins.min.css'},
+    {project: "layout", path: path['uliweb_layout'] + '/layout/static/layout.css'}
+];
+
+gulp.task("css_old", function () {
+
+    var ui = [], //存储uliweb_ui中需要拼接的css文件路径
+        layout = []; //存储uliweb_layout中需要拼接的css文件路径
+
+    //遍历common_css_list, 根据属性project判断属于ui还是layout,并将属性path的值放入对应数组待处理
+    for (var i = 0, len = common_css_list.length; i < len; i++) {
+        (common_css_list[i]['project'] == "ui") ? ui.push(common_css_list[i]['path']) : '';
+        (common_css_list[i]['project'] == "layout") ? layout.push(common_css_list[i]['path']) : '';
+    }
+
+    gulp.src(ui)
+        .pipe(concat("uliweb_ui.css"))
+        .pipe(gulp.dest("./dist"));
+
+    gulp.src(layout)
+        .pipe(concat("uliweb_layout.css"))
+        .pipe(gulp.dest("./dist"));
+
+});
+
+/*settings配置文件的格式:
+    [template_use.jqueryui]
+    toplinks[] = /Users/HoseaLee/Workspace/Uliwebext/uliweb-ui/uliweb_ui/static/modules/jquery-ui/1.11.4/jquery-ui.min.css
+    toplinks[] = ...
+    .
+    .
+    .
+    dist = common-ui
+
+    ps:[template_use.xxx] 插件名称以template_use开头, .xxx是插件名字,此版本不做他用,只用来区分插件
+        toplinks[] = xxx 插件中的一个文件,xxx是文件路径
+        dist = xxx 处理文件后归集到的文件名称的前缀,例如 dist = abc ,归集后js文件放到abc.js, css文件放到abc.css
+
+    文件归集的位置默认在./dist下, 如果gulp cli时以参数传入,则使用参数,且每次gulp都按照文件类型分类到js、css文件夹
+* */
+gulp.task("css", function () {
+    var default_options = {
+        dist: "common"
+    };
+    node_ini.parse(options.settings, function (err, data) {
+        var dists = [];
+        for (var k in data) {
+            var dist = data[k]['dist'];
+            if(!dist){
+                //如果没设置dist, 使用默认dist
+                dist = default_options.dist;
+            }
+            if (!dists[dist]) {
+                dists[dist] = {'css': [], 'js': []};
+            }
+            for (var i = 0, len = data[k]['toplinks'].length; i < len; i++) {
+                var link = data[k]['toplinks'][i];
+                if (link.indexOf(".css") > 0) {
+                    dists[dist]['css'].push(link);
+                } else if (link.indexOf(".js") > 0) {
+                    dists[dist]['js'].push(link);
+                }
+            }
+        }
+        for (var k in dists) {
+            var css_list = dists[k]['css'];
+            var js_list = dists[k]['js'];
+            gulp.src(css_list)
+                .pipe(concat(k + ".css"))
+                .pipe(gulp.dest(options.dist));
+            gulp.src(js_list)
+                .pipe(concat(k + ".js"))
+                .pipe(gulp.dest(options.dist));
+        }
+    });
+});
+
+gulp.task("default", ['css']);

--- a/uliweb_ui/settings.ini
+++ b/uliweb_ui/settings.ini
@@ -343,3 +343,7 @@ ui.ag-grid = '4.2.5'
 ui.ueditor = '1.4.3.3'
 ui.echarts = '3.2.3'
 ui.ztree = '3.5.24'
+
+[STATIC_COMBINE_CONFIG]
+enable = True
+init_static_combine = 'uliweb_ui.init_static_combine'


### PR DESCRIPTION
Now we can use 'uliweb gulpplugins -d appname' to concat plugins(css & js)
Please add config in settings like that:
[TEMPLATE_GULP]
you_want_name = [ "plugins_name"... ]